### PR TITLE
Pass in ms instead of the delta

### DIFF
--- a/src/TweenManager.js
+++ b/src/TweenManager.js
@@ -8,14 +8,12 @@ export default class TweenManager {
       this._last = 0;
   }
 
-  update(delta){
-    let deltaMS;
-    if(!delta && delta !== 0){
+  update(deltaMS){
+    if(!deltaMS && deltaMS !== 0){
       deltaMS = this._getDeltaMS();
-      delta = deltaMS/1000;
-    }else{
-      deltaMS = delta*1000;
     }
+
+    var delta = deltaMS/1000;
 
     for(let i = 0; i < this.tweens.length; i++){
       let tween = this.tweens[i];


### PR DESCRIPTION
I know it's an API change you may not want to accept, but in my usage, I found it didn't make sense to pass in a delta. If no delta was passed in, then it would call an internal function to get the time difference in ms. So why not, when passing a value in, you only bypass that internal function by supplying your own ms value.